### PR TITLE
Added new feature for hold timer

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/hold-timer/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/hold-timer/config.ts
@@ -1,0 +1,8 @@
+import { getFeatureFlags } from '../../utils/configuration';
+import HoldTimerConfig from './types/ServiceConfiguration';
+
+const { enabled = false } = (getFeatureFlags()?.features?.hold_timer as HoldTimerConfig) || {};
+
+export const isFeatureEnabled = () => {
+  return enabled;
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/hold-timer/flex-hooks/actions/HoldTimer.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/hold-timer/flex-hooks/actions/HoldTimer.ts
@@ -1,0 +1,75 @@
+import * as Flex from '@twilio/flex-ui';
+
+export const actionHook = function setHoldTimer(flex: typeof Flex, manager: Flex.Manager) {
+  console.log('setHoldMusicBeforeHoldCall hook initiated');
+
+  (window as any).Handlebars.registerHelper('CustomTaskLineCallAssigned', (payload: any) => {
+    const task = payload?.data?.root?.task;
+    const { status, duration } = getParticipantStatus(task);
+
+    if (duration) {
+      return `${status} | ${duration}`;
+    }
+    return status;
+  });
+
+  manager.strings.TaskLineCallAssigned = '{{CustomTaskLineCallAssigned}}';
+  manager.strings.TaskHeaderStatusAccepted = '{{CustomTaskLineCallAssigned}}';
+  manager.strings.SupervisorTaskLive = '{{CustomTaskLineCallAssigned}}';
+  manager.strings.TaskHeaderGroupCallAccepted =
+    "{{CustomTaskLineCallAssigned}} | {{{icon name='Participant'}}} {{tsk.conference.liveParticipantCount}}";
+  manager.strings.TaskLineGroupCallAssigned =
+    "{{CustomTaskLineCallAssigned}} | {{{icon name='Participant'}}} {{task.conference.liveParticipantCount}}";
+  manager.strings.SupervisorTaskGroupCall = '{{CustomTaskLineCallAssigned}} | {{task.conference.liveParticipantCount}}';
+};
+
+const getCustomerParticipant = (task: Flex.ITask): Flex.ConferenceParticipant | undefined => {
+  const conferenceChildren = task?.conference?.participants || [];
+  const customerParticipant = conferenceChildren.find((p) => p?.participantType === 'customer');
+  console.debug('Customer participant found:', customerParticipant);
+  return customerParticipant;
+};
+
+const formatTimeDuration = (milliseconds: number): string => {
+  const seconds = Math.floor(milliseconds / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+
+  let result;
+  if (hours > 0) {
+    result = `${hours}h ${minutes % 60}m`;
+  } else if (minutes > 0) {
+    result = `${minutes}m ${seconds % 60}s`;
+  } else {
+    result = `${seconds}s`;
+  }
+  return result;
+};
+
+const getParticipantStatus = (task: Flex.ITask): { status: string; duration: string } => {
+  const customerParticipant = getCustomerParticipant(task);
+
+  const isCustomerOnHold = customerParticipant?.onHold;
+  const customerUpdatedTimestamp = customerParticipant?.mediaProperties?.timestamp;
+
+  let timeSinceTaskUpdated;
+  if (task?.dateUpdated) {
+    timeSinceTaskUpdated = Math.max(Date.now() - task.dateUpdated.getTime(), 0);
+  }
+
+  let timeSinceCustomerUpdated;
+  if (isCustomerOnHold && customerUpdatedTimestamp) {
+    timeSinceCustomerUpdated = Math.max(Date.now() - new Date(customerUpdatedTimestamp).getTime(), 0);
+  }
+
+  const status = isCustomerOnHold ? 'Hold' : 'Live';
+  let duration = '';
+
+  if (isCustomerOnHold && timeSinceCustomerUpdated) {
+    duration = formatTimeDuration(timeSinceCustomerUpdated);
+  } else if (!isCustomerOnHold && timeSinceTaskUpdated) {
+    duration = formatTimeDuration(timeSinceTaskUpdated);
+  }
+
+  return { status, duration };
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/hold-timer/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/hold-timer/index.ts
@@ -1,0 +1,9 @@
+import { FeatureDefinition } from '../../types/feature-loader';
+import { isFeatureEnabled } from './config';
+// @ts-ignore
+import hooks from './flex-hooks/**/*.*';
+
+export const register = (): FeatureDefinition => {
+  if (!isFeatureEnabled()) return {};
+  return { name: 'hold-timer', hooks: typeof hooks === 'undefined' ? [] : hooks };
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/hold-timer/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/hold-timer/types/ServiceConfiguration.ts
@@ -1,0 +1,3 @@
+export default interface HoldTimerConfig {
+  enabled: boolean;
+}


### PR DESCRIPTION
### Summary

Integrated the Twilio Professional Services "Hold Time" plugin into the existing Twilio Flex template. This feature adds functionality to display the duration of time a participant has been on hold in the Flex UI, enhancing the visibility of hold times for agents and supervisors.

### Checklist

- [x] Tested changes end to end
- [x] Updated documentation
- [ ] Requested one or more reviewers
