### PR TITLE
Added supervisor role to update the config

### DIFF
--- a/serverless-functions/src/functions/features/admin-ui/flex/update-config.js
+++ b/serverless-functions/src/functions/features/admin-ui/flex/update-config.js
@@ -9,7 +9,7 @@ exports.handler = prepareFlexFunction(requiredParameters, async (context, event,
   try {
     const { attributesUpdate, mergeFeature, TokenResult } = event;
 
-    if (TokenResult.roles.indexOf('admin') < 0) {
+    if (TokenResult.roles.indexOf('admin') < 0 && TokenResult.roles.indexOf('supervisor') < 0) {
       response.setStatusCode(403);
       response.setBody('Not authorized');
       return callback(null, response);


### PR DESCRIPTION
### Summary

Added a logic check to validate if a user has either 'admin' or 'supervisor' roles before proceeding. If neither role is found, the user will be restricted.

### Checklist

- [x] Tested changes end to end
- [ ] Updated documentation
- [ ] Requested one or more reviewers
