### PR TITLE
feat: Add ability to hide specific activities in Teams View filters

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/config.ts
@@ -1,8 +1,11 @@
 import { getFeatureFlags } from '../../utils/configuration';
 import TeamViewFiltersConfig from './types/ServiceConfiguration';
 
-const { enabled = false, log_filters = false } =
-  (getFeatureFlags().features?.teams_view_filters as TeamViewFiltersConfig) || {};
+const {
+  enabled = false,
+  log_filters = false,
+  hide_specific_activities = [],
+} = (getFeatureFlags().features?.teams_view_filters as TeamViewFiltersConfig) || {};
 const {
   activities = true,
   email = false,
@@ -48,6 +51,10 @@ export const isTeamFilterEnabled = () => {
 
 export const isAgentSkillsFilterEnabled = () => {
   return enabled && agent_skills;
+};
+
+export const getHiddenActivities = () => {
+  return hide_specific_activities;
 };
 
 export const getDepartmentOptions = () => {

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/activitiesFilter.tsx
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/filters/activitiesFilter.tsx
@@ -1,12 +1,16 @@
 import { FilterDefinition, Manager, FiltersListItemType } from '@twilio/flex-ui';
 
 import { StringTemplates } from '../flex-hooks/strings/TeamViewQueueFilter';
+import { getHiddenActivities } from '../config';
 
 const activities = Array.from(Manager.getInstance().store.getState().flex.worker.activities);
+const hiddenActivities = getHiddenActivities();
 
 /* 
   This filter exists solely to provide the ability to translate the title,
   as the one included with Flex is only available in English.
+  
+  Now also supports hiding specific activities based on configuration.
   */
 
 export const activitiesFilter = () =>
@@ -15,11 +19,13 @@ export const activitiesFilter = () =>
     title: (Manager.getInstance().strings as any)[StringTemplates.Activities],
     fieldName: 'activity_name',
     options: activities
-      ? activities.map((activity: any) => ({
-          value: activity[1].name,
-          label: activity[1].name,
-          default: false,
-        }))
+      ? activities
+          .map((activity: any) => ({
+            value: activity[1].name,
+            label: activity[1].name,
+            default: false,
+          }))
+          .filter((option: any) => !hiddenActivities.includes(option.value))
       : [],
     type: FiltersListItemType.multiValue,
     condition: 'IN',

--- a/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/types/ServiceConfiguration.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/teams-view-filters/types/ServiceConfiguration.ts
@@ -10,4 +10,5 @@ export default interface TeamViewFiltersConfig {
     team: boolean;
     agent_skills: boolean;
   };
+  hide_specific_activities?: string[];
 }


### PR DESCRIPTION
- Added new hide_specific_activities configuration option
- Updated ServiceConfiguration type definition
- Modified activitiesFilter to filter out specified activities
- Allows hiding specific activity types from Teams View

### Summary

_Provide a summary of the change_

### Checklist

- [ ] Tested changes end to end
- [ ] Updated documentation
- [ ] Requested one or more reviewers
