### PR TITLE
Add audit log feature

### DIFF
--- a/plugin-flex-ts-template-v2/src/feature-library/audit-logging/README.md
+++ b/plugin-flex-ts-template-v2/src/feature-library/audit-logging/README.md
@@ -1,0 +1,3 @@
+# Audit Logging Feature
+
+This feature captures administrator changes to worker skills and writes audit entries to a Sync map.  Logs include the worker sid, the admin performing the change, previous attributes and new attributes.

--- a/plugin-flex-ts-template-v2/src/feature-library/audit-logging/config.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/audit-logging/config.ts
@@ -1,0 +1,6 @@
+import { getFeatureFlags } from '../../utils/configuration';
+
+const { enabled = false, sync_map_name = 'AuditLogs' } = getFeatureFlags()?.features?.audit_logging || {};
+
+export const isFeatureEnabled = () => enabled;
+export const getSyncMapName = () => sync_map_name;

--- a/plugin-flex-ts-template-v2/src/feature-library/audit-logging/flex-hooks/actions/AfterUpdateWorkerAttributes.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/audit-logging/flex-hooks/actions/AfterUpdateWorkerAttributes.ts
@@ -1,0 +1,28 @@
+import TaskRouterService from '../../../utils/serverless/TaskRouter/TaskRouterService';
+import AuditLogService from '../../utils/AuditLogService';
+import * as Flex from '@twilio/flex-ui';
+import { FlexActionEvent, FlexAction } from '../../../types/feature-loader';
+
+export const actionEvent = FlexActionEvent.replace;
+export const actionName = FlexAction.UpdateWorkerAttributes as any;
+
+export const actionHook = function logWorkerSkillChange(flex: typeof Flex, manager: Flex.Manager) {
+  const original = TaskRouterService.updateWorkerAttributes.bind(TaskRouterService);
+  TaskRouterService.updateWorkerAttributes = async (workerSid: string, attributesUpdate: string) => {
+    const adminSid = manager.user?.sid || 'unknown';
+    const previous = manager.workerClient?.workers?.get(workerSid)?.attributes || {};
+    const result = await original(workerSid, attributesUpdate);
+    try {
+      await AuditLogService.logSkillChange(
+        workerSid,
+        adminSid,
+        'update_attributes',
+        JSON.stringify(previous),
+        attributesUpdate,
+      );
+    } catch (e) {
+      console.error('audit-log failed', e);
+    }
+    return result;
+  };
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/audit-logging/index.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/audit-logging/index.ts
@@ -1,0 +1,9 @@
+import { FeatureDefinition } from '../../types/feature-loader';
+import { isFeatureEnabled } from './config';
+// @ts-ignore
+import hooks from './flex-hooks/**/*.*';
+
+export const register = (): FeatureDefinition => {
+  if (!isFeatureEnabled()) return {};
+  return { name: 'audit-logging', hooks: typeof hooks === 'undefined' ? [] : hooks };
+};

--- a/plugin-flex-ts-template-v2/src/feature-library/audit-logging/utils/AuditLogService.ts
+++ b/plugin-flex-ts-template-v2/src/feature-library/audit-logging/utils/AuditLogService.ts
@@ -1,0 +1,27 @@
+import ApiService from '../../../utils/serverless/ApiService';
+import { EncodedParams } from '../../../types/serverless';
+
+export interface LogResponse { success: boolean; }
+
+class AuditLogService extends ApiService {
+  async logSkillChange(workerSid: string, adminSid: string, changeType: string, previousValue: string, newValue: string): Promise<LogResponse> {
+    const encodedParams: EncodedParams = {
+      workerSid: encodeURIComponent(workerSid),
+      adminSid: encodeURIComponent(adminSid),
+      changeType: encodeURIComponent(changeType),
+      previousValue: encodeURIComponent(previousValue),
+      newValue: encodeURIComponent(newValue),
+      Token: encodeURIComponent(this.manager.user.token),
+    };
+    return this.fetchJsonWithReject<LogResponse>(
+      `${this.serverlessProtocol}://${this.serverlessDomain}/features/audit-log/log-skill-change`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: this.buildBody(encodedParams),
+      },
+    );
+  }
+}
+
+export default new AuditLogService();

--- a/serverless-functions/src/functions/features/audit-log/README.md
+++ b/serverless-functions/src/functions/features/audit-log/README.md
@@ -1,0 +1,3 @@
+# Audit Log Functions
+
+These functions are examples for storing audit events via Twilio Sync. `log-skill-change` is invoked by the Flex plugin while `process-event-stream` can be used as a webhook for Flex event streams.

--- a/serverless-functions/src/functions/features/audit-log/flex/log-skill-change.js
+++ b/serverless-functions/src/functions/features/audit-log/flex/log-skill-change.js
@@ -1,0 +1,23 @@
+const { prepareFlexFunction } = require(Runtime.getFunctions()['common/helpers/function-helper'].path);
+
+const requiredParameters = [
+  { key: 'workerSid', purpose: 'worker sid being updated' },
+  { key: 'adminSid', purpose: 'sid of administrator performing change' },
+  { key: 'changeType', purpose: 'type of change' },
+  { key: 'previousValue', purpose: 'previous skills json' },
+  { key: 'newValue', purpose: 'new skills json' },
+];
+
+exports.handler = prepareFlexFunction(requiredParameters, async (context, event, callback, response, handleError) => {
+  const client = context.getTwilioClient();
+  try {
+    const map = await client.sync.v1.services(context.TWILIO_FLEX_SYNC_SID).syncMaps.create({ uniqueName: 'AuditLogs' });
+    await client.sync.v1.services(context.TWILIO_FLEX_SYNC_SID)
+      .syncMaps(map.sid)
+      .syncMapItems.create({ data: { ...event, timestamp: Date.now() } });
+    response.setBody({ success: true });
+    return callback(null, response);
+  } catch (error) {
+    return handleError(error);
+  }
+});

--- a/serverless-functions/src/functions/features/audit-log/flex/process-event-stream.js
+++ b/serverless-functions/src/functions/features/audit-log/flex/process-event-stream.js
@@ -1,0 +1,11 @@
+exports.handler = async function(context, event, callback) {
+  const client = context.getTwilioClient();
+  const data = { ...event, timestamp: Date.now() };
+  try {
+    const map = await client.sync.v1.services(context.TWILIO_FLEX_SYNC_SID).syncMaps.create({ uniqueName: 'AuditLogsEvents' });
+    await client.sync.v1.services(context.TWILIO_FLEX_SYNC_SID).syncMaps(map.sid).syncMapItems.create({ data });
+    return callback(null, data);
+  } catch (e) {
+    return callback(e);
+  }
+};


### PR DESCRIPTION
## Summary
- add example audit logging feature for Flex plugin
- include serverless functions for logging skill changes and event stream processing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451980ccc08326879b6cbd7e3e6721